### PR TITLE
Add security and accessibility improvements

### DIFF
--- a/src/components/astro/Nav.astro
+++ b/src/components/astro/Nav.astro
@@ -16,6 +16,7 @@ const sydLink =
   <span class={styles}>
     <a
       target="_blank"
+      rel="noopener noreferrer"
       href="https://www.github.com/chav-aniket"
       class="hover-scale-lg inline-block"
     >
@@ -25,13 +26,14 @@ const sydLink =
   <span class={styles}>
     <a
       target="_blank"
+      rel="noopener noreferrer"
       href="https://www.linkedin.com/in/chavaniket/"
       class="hover-scale-lg inline-block"
     >
       <LinkedInIcon client:load base={base} scale={scale} style="" />
     </a>
   </span>
-  <a target="_blank" href={sydLink} class="hover-scale">
+  <a target="_blank" rel="noopener noreferrer" href={sydLink} class="hover-scale">
     <IconPill
       class="hover-glow md:text-md rounded-full pt-0.5 align-middle text-sm xl:text-lg bg-secondary-light dark:bg-secondary-dark"
     >

--- a/src/components/astro/Repo.astro
+++ b/src/components/astro/Repo.astro
@@ -14,6 +14,7 @@ const { name, description, language, stargazers, link } = Astro.props.repo;
 <a
   href={link}
   target="_blank"
+  rel="noopener noreferrer"
   class="
     repo-card group/repo relative my-4 p-4 overflow-hidden
     rounded-md border-4 border-secondary-light dark:border-secondary-dark

--- a/src/components/svelte/ThemeToggle.svelte
+++ b/src/components/svelte/ThemeToggle.svelte
@@ -33,6 +33,7 @@
     class="peer h-0 w-0 opacity-0"
     checked={isDark}
     on:click={handleClick}
+    aria-label="Toggle dark mode"
   />
   <span
     class="

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,6 +27,7 @@ const repoResult: RepoResult = await fetchRepos();
             <span class="inline-block sm:whitespace-nowrap">
               @<a
                 target="_blank"
+                rel="noopener noreferrer"
                 href="https://www.atlassian.com"
                 class="hover-scale inline-block align-middle"
               >


### PR DESCRIPTION
## Summary
- Add `rel="noopener noreferrer"` to all external links with `target="_blank"` to prevent reverse tabnabbing
- Add `aria-label="Toggle dark mode"` to the theme toggle checkbox for screen reader accessibility

## Files Changed
- `src/components/astro/Nav.astro` - GitHub, LinkedIn, and location links
- `src/components/astro/Repo.astro` - Repository card links
- `src/pages/index.astro` - Atlassian link
- `src/components/svelte/ThemeToggle.svelte` - Theme toggle accessibility

## Test plan
- [ ] Verify external links still open in new tabs
- [ ] Test theme toggle with screen reader
- [ ] Run build to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)